### PR TITLE
Fix destruction of parent scope

### DIFF
--- a/lib/angular-fancy-modal.js
+++ b/lib/angular-fancy-modal.js
@@ -216,7 +216,7 @@
 
             modal.bind('click', closeByAction);
             modal.append(content);
-            $body.append(modal);
+            $body.append($compile(modal)(scope));
             var id = 'fancymodal-'+incrementalId;
             var $modal = {
               id: id,


### PR DESCRIPTION
The cleanUp function destroys the parent scope. It happens because $modal.scope() is actually a parent scope: only htmlTemplate which contains it is $compiled, but the container is not.

See the demo here: http://symbi.org/misc/fancyscope.html

The obvious fix is to $compile modal before appending to body, that's what is done. The fix demo: http://symbi.org/misc/fancyscope-fix.html